### PR TITLE
Simplify parallel execution to use only xargs instead of GNU parallel

### DIFF
--- a/src/download_all_github_repos.sh
+++ b/src/download_all_github_repos.sh
@@ -393,7 +393,9 @@ clone_repos() {
             dir=$(basename "$converted" .git)
             if [[ -d "$dir" ]]; then exit 0; fi
             flags=()
-            '"$SHALLOW"' && flags+=(--depth 1)
+            if [ "$SHALLOW" = true ]; then
+                flags+=(--depth 1)
+            fi
             '"$MIRROR"' && flags+=(--mirror)
             git clone "${flags[@]}" "$converted"
         '


### PR DESCRIPTION
- Remove GNU parallel detection and complexity
- Use only xargs -P for parallel execution, which is more portable
- Simplified code is more maintainable and less error-prone
- xargs -P is widely available on most Unix-like systems