### PR TITLE
Refactor commit date modifier to support multiple modes

### DIFF
--- a/src/change_commit_date.sh
+++ b/src/change_commit_date.sh
@@ -231,7 +231,7 @@ move_history() {
 
   git filter-branch -f --tag-name-filter cat --env-filter "
     tz='${TZ_OFFSET}'
-    tz_secs=$(tz_to_seconds '${TZ_OFFSET}')  # <- will be substituted by this script (not inside env-filter)
+    tz_secs=$(tz_to_seconds "${TZ_OFFSET}")
   " -- --branches --tags >/dev/null 2>&1 && true
 
   # We need the tz_to_seconds helper inside the filter; inject it plus logic:


### PR DESCRIPTION
Updated the script to provide powerful Git commit-date tools including options to amend the latest commit date, shift all commits, and move commits into day or night hours. Enhanced usage examples and added timezone handling.